### PR TITLE
Extract NamedTemporaryFile name in the download zip function

### DIFF
--- a/torchutil/download.py
+++ b/torchutil/download.py
@@ -59,6 +59,6 @@ def zip(url: 'str', path: Union[str, bytes, os.PathLike]):
         path - The location to save results
     """
     with tempfile.NamedTemporaryFile() as tmp:
-        file(url, tmp)
+        file(url, tmp.name)
         with zipfile.ZipFile(tmp, 'r') as zfile:
             zfile.extractall(path)


### PR DESCRIPTION
related to issue https://github.com/maxrmorrison/torchutil/issues/2

This fix made it possible for me to download the *ptdb* dataset, the error mentioned in the issue no longer happens.